### PR TITLE
Fix tree-shaking for deduped modules, fixes #4

### DIFF
--- a/test/dedupe/a/index.js
+++ b/test/dedupe/a/index.js
@@ -1,0 +1,3 @@
+// whatever
+exports.whatever = require('./whatever')
+exports.something = function () {}

--- a/test/dedupe/a/whatever.js
+++ b/test/dedupe/a/whatever.js
@@ -1,0 +1,2 @@
+exports.message = 'whatever a'
+exports.lol = function () {}

--- a/test/dedupe/app.js
+++ b/test/dedupe/app.js
@@ -1,0 +1,5 @@
+var a = require('./a')
+var b = require('./b')
+
+a.something()
+b.whatever()

--- a/test/dedupe/b/index.js
+++ b/test/dedupe/b/index.js
@@ -1,0 +1,3 @@
+// whatever
+exports.whatever = require('./whatever')
+exports.something = function () {}

--- a/test/dedupe/b/whatever.js
+++ b/test/dedupe/b/whatever.js
@@ -1,0 +1,2 @@
+exports.message = 'whatever b'
+exports.do = function () {}

--- a/test/dedupe/expected.js
+++ b/test/dedupe/expected.js
@@ -1,0 +1,23 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+// whatever
+exports.whatever = require('./whatever')
+exports.something = function () {}
+
+},{"./whatever":2}],2:[function(require,module,exports){
+exports.message = 'whatever a'
+exports.lol = function () {}
+
+},{}],3:[function(require,module,exports){
+var a = require('./a')
+var b = require('./b')
+
+a.something()
+b.whatever()
+
+},{"./a":1,"./b":4}],4:[function(require,module,exports){
+arguments[4][1][0].apply(exports,arguments)
+},{"./whatever":5,"dup":1}],5:[function(require,module,exports){
+exports.message = 'whatever b'
+exports.do = function () {}
+
+},{}]},{},[3]);


### PR DESCRIPTION
Used declarations for different deduped versions of modules are merged together by checking for each module's `isUsed(name)`.